### PR TITLE
fix: score fully-labelled binary fields correctly (ONC-12248)

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,0 +1,54 @@
+# AGENTS.md — llm-validation-framework
+
+Agent entry point for this repo. Read before making changes. The working tree is the
+source of truth over stale docs.
+
+> **This is a public repository** (published to PyPI as `llmvalidate`). Everything here —
+> commits, branch names, PR titles, issues — is visible to the world. Do **not** reference internal tooling, customer names, or any non-public information in commit messages, code comments, or docs. However, you can mention internal tickets.
+
+## What this is
+
+`llmvalidate` — a standalone PyPI package that evaluates LLM-extracted structured data
+against ground truth. Source in `src/llmvalidate/`, tests in `tests/`.
+
+## Releases are automatic — your commit message controls the version
+
+This repo uses **python-semantic-release**. Every push to `master` (via merged PR) runs
+`.github/workflows/ci-release.yml`, which reads the **Conventional Commit** history since
+the last release, bumps the version (`src/llmvalidate/__init__.py` + `pyproject.toml`),
+tags it, and **publishes to PyPI**. There is no manual version bump — never edit
+`__version__` by hand.
+
+The prefix exists **only to trigger a release** — it is not a style rule for every commit.
+semantic-release scans all commits merged to `master` and bumps the version from the
+highest-ranked type it finds (`feat:` > `fix:`). So **one commit per PR carrying the right
+prefix is enough**; the rest can have any message you like. If no commit in the PR has a
+recognized type, **no release fires**. When a prefix is used, the type token must come first,
+before the colon.
+
+### Commit format (for the release-triggering commit)
+
+At least one commit in the PR should use:
+
+```
+<type>: <imperative description>
+```
+
+| Type            | Effect on version | Use for                          |
+|-----------------|-------------------|----------------------------------|
+| `fix:`          | patch (0.0.x)     | bug fixes                        |
+| `feat:`         | minor (0.x.0)     | new features                     |
+| `BREAKING CHANGE:` footer | major (x.0.0) | backward-incompatible changes |
+| `docs:`, `chore:`, `test:`, `refactor:` | no release | non-shipping changes |
+
+Examples:
+- `fix: correct all-zero metrics for binary fields`
+- `feat: add per-field confidence scoring`
+- `docs: add AGENTS.md`
+
+## Branch & PR conventions
+
+- Branch from `origin/master` with a short kebab-case summary, e.g. `fix-binary-field-metrics`.
+- One concern per PR; keep PR titles in Conventional Commit style (`fix:` / `feat:` / `docs:`).
+- Run the test suite before opening a PR: `pytest` (configured via `[tool.pytest.ini_options]`,
+  `pythonpath = ["src"]`).

--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -16,7 +16,16 @@ def compare_results_binary(expected, actual):
     if (is_expected_undefined(expected)):
         return {'TP': None, 'TN': None, 'FP': None, 'FN': None}
 
-    TP = 1 if expected is True and actual is True else 0 
+    # numpy bool scalars (produced when an all-bool object column is re-inferred to
+    # a numpy `bool` dtype, e.g. by convert_lists' DataFrame.map) fail identity
+    # checks like `value is True`, which would otherwise score every row 0 for a
+    # fully-labelled binary field (ONC-12248). Normalize to native Python bools.
+    if isinstance(expected, np.bool_):
+        expected = bool(expected)
+    if isinstance(actual, np.bool_):
+        actual = bool(actual)
+
+    TP = 1 if expected is True and actual is True else 0
     FN = 1 if expected is True and actual is not True else 0 
     TN = 1 if expected is False and actual is False else 0
     FP = 1 if expected is False and actual is not False else 0

--- a/tests/binary_field_metrics_test.py
+++ b/tests/binary_field_metrics_test.py
@@ -1,0 +1,40 @@
+import math
+import pandas as pd
+import numpy as np
+import pytest
+import llmvalidate.validation as v
+
+
+def test_fully_labelled_binary_field_metrics_through_validate():
+    # Regression for ONC-12248: a fully-labelled (no NaN) binary field used to
+    # silently produce all-zero confusion counts because validate()->convert_lists
+    # re-infers the all-bool column to numpy bool, whose scalars fail `is True`.
+    src = pd.DataFrame({
+        "Has metastasis":      pd.Series([True, False, True, False], dtype=object),
+        "Res: Has metastasis": pd.Series([True, False, True, True],  dtype=object),
+    })
+
+    _, metrics = v.validate(
+        src, ["Has metastasis"], structure_callback=None, output_folder=None
+    )
+
+    row = metrics[metrics["field"] == "Has metastasis"].iloc[0]
+
+    assert row["TP"] == 2
+    assert row["FP"] == 1
+    assert row["FN"] == 0
+    assert row["TN"] == 1
+
+    assert row["precision (micro)"] == pytest.approx(2 / 3)
+    assert row["recall (micro)"] == pytest.approx(1.0)
+    assert row["F1 score (micro)"] == pytest.approx(0.8)
+
+
+def test_compare_results_binary_accepts_numpy_bool():
+    # numpy.bool_ inputs must score identically to native Python bools.
+    assert v.compare_results_binary(np.True_, np.True_) == {"TP": 1, "TN": 0, "FP": 0, "FN": 0}
+    assert v.compare_results_binary(np.False_, np.False_) == {"TP": 0, "TN": 1, "FP": 0, "FN": 0}
+    assert v.compare_results_binary(np.True_, np.False_) == {"TP": 0, "TN": 0, "FP": 0, "FN": 1}
+    assert v.compare_results_binary(np.False_, np.True_) == {"TP": 0, "TN": 0, "FP": 1, "FN": 0}
+    # native bools still behave exactly as before
+    assert v.compare_results_binary(True, True) == {"TP": 1, "TN": 0, "FP": 0, "FN": 0}


### PR DESCRIPTION
## Summary
- `compare_results_binary` compared boolean labels by **identity** (`expected is True` / `actual is True`). For a **fully-labelled** binary field (no NaN rows), `validate()` → `convert_lists()` (`DataFrame.map`) re-infers the all-bool `object` column back to a numpy `bool` dtype, so `df.iterrows()` yields `numpy.bool_` scalars. `numpy.bool_(True) is True` is `False`, so every row scored TP=TN=FP=FN=0 **silently** and precision/recall/F1 columns were dropped.
- Fix: normalize `numpy.bool_` scalars to native Python `bool` before the identity checks. `convert_lists` is left untouched; the fix is the minimal, robust one and works regardless of how the dtype got inferred.
- Partially-labelled binary fields (and `samples.csv`) were unaffected and remain so.

## Jira
ONC-12248

## Test plan
- [x] Full suite green: **74 passed** (was 72; +2 new regression tests)
- [x] New `tests/binary_field_metrics_test.py`:
  - end-to-end through `validate()` with a fully-labelled binary field → TP=2, FP=1, FN=0, TN=1, precision (micro)=2/3, recall (micro)=1.0, F1 (micro)=0.8
  - direct `compare_results_binary` with `numpy.bool_` inputs scores identically to native bools
- [x] Ticket repro now yields TP=2/FP=1/FN=0/TN=1 (previously all 0)

## Notes
- Also includes the repo's `AGENTS.MD` agent-docs file (was staged on `master`; included here per maintainer decision).
- `fix:` prefix drives a patch release via python-semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)