### PR TITLE
ONC-12248: fix all-zero metrics for fully-labelled binary fields

### DIFF
--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -10,16 +10,38 @@ import concurrent.futures as cf
 from tqdm import tqdm
 from .utils import convert_lists, infer_fields
 
+def _equals_bool(value, target):
+    """True iff `value` equals the boolean `target` by value.
+
+    Results may arrive as ``numpy.bool_`` (an all-bool column gets re-inferred
+    away from ``object`` dtype by :func:`convert_lists`), and
+    ``numpy.bool_(True) is True`` is ``False`` — so identity checks silently
+    miss every row. Undefined values (None / NaN / "") match neither True nor
+    False, preserving the original "missing prediction is a miss" semantics.
+    """
+    if is_expected_undefined(value):
+        return False
+    try:
+        return bool(value) == target
+    except (TypeError, ValueError):
+        return False
+
+
 def compare_results_binary(expected, actual):
     """Compares boolean labels and returns confusion matrix counts."""
 
     if (is_expected_undefined(expected)):
         return {'TP': None, 'TN': None, 'FP': None, 'FN': None}
 
-    TP = 1 if expected is True and actual is True else 0 
-    FN = 1 if expected is True and actual is not True else 0 
-    TN = 1 if expected is False and actual is False else 0
-    FP = 1 if expected is False and actual is not False else 0
+    expected_true = _equals_bool(expected, True)
+    expected_false = _equals_bool(expected, False)
+    actual_true = _equals_bool(actual, True)
+    actual_false = _equals_bool(actual, False)
+
+    TP = 1 if expected_true and actual_true else 0
+    FN = 1 if expected_true and not actual_true else 0
+    TN = 1 if expected_false and actual_false else 0
+    FP = 1 if expected_false and not actual_false else 0
 
     return {"TP": TP, "TN": TN, "FP": FP, "FN": FN}
 

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -1,4 +1,5 @@
 ﻿import pandas as pd
+import numpy as np
 import pytest
 import llmvalidate.validation as v
 from llmvalidate.utils import convert_lists
@@ -758,3 +759,43 @@ def test_reorder_result_columns():
     assert drugs_comment_idx == drugs_correct_idx + 1, "Related columns should be consecutive"
     
     print("✓ All tests passed! Column reordering works correctly.")
+
+
+# ONC-12248: a fully-labelled binary field was silently returning all-zero
+# confusion counts. compare_results_binary compared by identity, but
+# numpy.bool_(True) is True -> False, so every row was missed. These tests lock
+# in the value-based comparison while preserving the three-way semantics.
+def test_compare_results_binary_numpy_bool_and_semantics():
+    # numpy.bool_ inputs must be compared by value, not identity (the bug fix)
+    assert v.compare_results_binary(np.bool_(True), np.bool_(True)) == {"TP": 1, "TN": 0, "FP": 0, "FN": 0}
+    assert v.compare_results_binary(np.bool_(False), np.bool_(False)) == {"TP": 0, "TN": 1, "FP": 0, "FN": 0}
+    assert v.compare_results_binary(np.bool_(False), np.bool_(True)) == {"TP": 0, "TN": 0, "FP": 1, "FN": 0}
+
+    # native python bools behave identically
+    assert v.compare_results_binary(True, True) == {"TP": 1, "TN": 0, "FP": 0, "FN": 0}
+    assert v.compare_results_binary(True, False) == {"TP": 0, "TN": 0, "FP": 0, "FN": 1}
+    assert v.compare_results_binary(False, True) == {"TP": 0, "TN": 0, "FP": 1, "FN": 0}
+
+    # undefined actual is still a miss (FN if expected True, FP if expected False)
+    assert v.compare_results_binary(True, np.nan)["FN"] == 1
+    assert v.compare_results_binary(False, np.nan)["FP"] == 1
+
+
+# ONC-12248: regression test through the full validate() path for a
+# fully-labelled binary field, which is exactly the path that was broken
+# (the all-bool column gets re-inferred to numpy bool dtype by convert_lists).
+def test_validate_fully_labelled_binary_field():
+    src = pd.DataFrame({
+        "Has metastasis":      pd.Series([True, False, True, False], dtype=object),
+        "Res: Has metastasis": pd.Series([True, False, True, True],  dtype=object),
+    })
+    _, metrics = v.validate(src, ["Has metastasis"], structure_callback=None, output_folder=None)
+
+    row = metrics.loc[metrics["field"] == "Has metastasis"].iloc[0]
+    assert row["TP"] == 2
+    assert row["FP"] == 1
+    assert row["FN"] == 0
+    assert row["TN"] == 1
+    assert row["precision (micro)"] == pytest.approx(2 / 3)
+    assert row["recall (micro)"] == pytest.approx(1.0)
+    assert row["F1 score (micro)"] == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
A **fully-labelled** binary (True/False) field silently returned all-zero confusion counts (TP=TN=FP=FN=0), dropping precision/recall/F1 entirely.

**Root cause:** `convert_lists` uses `DataFrame.map`, which re-infers an all-bool `object` column back to numpy `bool` dtype. `iterrows` then yields `numpy.bool_` scalars, and `compare_results_binary` compared by **identity** (`expected is True`) — but `numpy.bool_(True) is True` is `False`, so every row scored 0. Partially-labelled columns survived because their `NaN`s kept the column `object` (native Python `bool`), which is why `samples.csv` and the existing `flag` test never exercised this path.

**Fix:** `compare_results_binary` now compares **by value** via a small `_equals_bool` helper, while preserving the original three-way semantics — an undefined `actual` (None/NaN/"") still counts as a miss (FN when expected True, FP when expected False). `convert_lists` is left untouched; the comparison fix is robust regardless of upstream dtype.

## Jira
ONC-12248

## Test plan
- [x] Full suite green: **74 passed** (72 pre-existing + 2 new), no test weakened
- [x] New unit test locks the `numpy.bool_` fix + native-bool parity + undefined-actual FN/FP semantics
- [x] New integration test runs a fully-labelled binary field through `validate()` → TP=2, FP=1, FN=0, TN=1, precision=2/3, recall=1.0, F1=0.8 (matches the ticket's expected output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)