### PR TITLE
ONC-12248: fix all-zero metrics for fully-labelled binary fields

### DIFF
--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -16,10 +16,20 @@ def compare_results_binary(expected, actual):
     if (is_expected_undefined(expected)):
         return {'TP': None, 'TN': None, 'FP': None, 'FN': None}
 
-    TP = 1 if expected is True and actual is True else 0 
-    FN = 1 if expected is True and actual is not True else 0 
-    TN = 1 if expected is False and actual is False else 0
-    FP = 1 if expected is False and actual is not False else 0
+    # Compare by value, not identity. validate() passes binary columns through
+    # convert_lists -> DataFrame.map, which re-infers an all-bool object column
+    # back to a numpy bool dtype, so iterrows yields numpy.bool_ scalars.
+    # numpy.bool_(True) is True evaluates to False, which silently zeroed every
+    # count for fully-labelled binary fields (ONC-12248). A missing/NaN actual
+    # is still treated as a wrong prediction, matching the previous behaviour.
+    expected_true = bool(expected)
+    actual_missing = is_scalar_empty(actual)
+    actual_true = (not actual_missing) and bool(actual)
+
+    TP = 1 if expected_true and actual_true else 0
+    FN = 1 if expected_true and not actual_true else 0
+    TN = 1 if (not expected_true) and (not actual_missing) and (not actual_true) else 0
+    FP = 1 if (not expected_true) and (actual_missing or actual_true) else 0
 
     return {"TP": TP, "TN": TN, "FP": FP, "FN": FN}
 

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -310,6 +310,41 @@ def test_validate_basic_no_confidence():
 
     assert metrics_df.loc[metrics_df.field == 'exceptions', 'field-present cases'].iloc[0] == 0
 
+def test_fully_labelled_binary_field_metrics():
+    """
+    Regression test for ONC-12248.
+
+    A fully-labelled binary field (every row labelled, dtype=object bools) is
+    passed through validate(). Internally convert_lists -> DataFrame.map re-infers
+    the all-bool object column back to a numpy bool dtype, so iterrows yields
+    numpy.bool_ scalars. The old identity comparison (numpy.bool_(True) is True ==
+    False) silently zeroed every confusion-matrix count. This asserts the counts
+    and metrics are now computed by value.
+    """
+    src = pd.DataFrame({
+        "Has metastasis":      pd.Series([True, False, True, False], dtype=object),
+        "Res: Has metastasis": pd.Series([True, False, True, True],  dtype=object),
+    })
+
+    _, metrics = v.validate(
+        src,
+        ["Has metastasis"],
+        structure_callback=None,
+        output_folder=None,
+    )
+
+    # Only one binary field is present, so get_metrics drops the all-'Overall'
+    # confidence column; look the row up by field directly.
+    row = metrics.loc[metrics.field == "Has metastasis"].iloc[0]
+    assert row['TP'] == 2
+    assert row['FP'] == 1
+    assert row['FN'] == 0
+    assert row['TN'] == 1
+    assert row['precision (micro)'] == pytest.approx(0.6667, abs=1e-4)
+    assert row['recall (micro)'] == pytest.approx(1.0)
+    assert row['F1 score (micro)'] == pytest.approx(0.8)
+
+
 def test_process_all_with_cases():
     """
     Verifies process_all independently:


### PR DESCRIPTION
## Summary
- `compare_results_binary` compared boolean labels by **identity** (`expected is True`, `actual is True`). `validate()` runs binary columns through `convert_lists` → `DataFrame.map`, which re-infers an all-bool `object` column back to a numpy `bool` dtype, so `iterrows()` yields `numpy.bool_` scalars. Since `numpy.bool_(True) is True` is `False`, every count was silently zeroed (TP=TN=FP=FN=0) for **fully-labelled** binary fields — partially-labelled columns (like the shipped `samples.csv`) stayed `object`/native-bool and masked the bug.
- Fix: compare by **value** (`bool(expected)`, `bool(actual)`), using `is_scalar_empty` to detect a missing `actual`. Missing/NaN `actual` is still treated as a wrong prediction (FN when expected True, FP when expected False), preserving prior behaviour for the partially-labelled path.
- Added a regression test using a fully-labelled object-bool field (the path `samples.csv` never exercised).

## Jira
ONC-12248

## Test plan
- [x] Full suite green: **73 passed** (`PYTHONPATH=src python -m pytest`)
- [x] New test `test_fully_labelled_binary_field_metrics` fails on old code, passes on fix
- [x] Asserts ticket's expected values: TP=2, FP=1, FN=0, TN=1, precision≈0.667, recall=1.0, F1≈0.8
- [x] No existing test weakened, skipped, or changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)