### PR TITLE
ONC-12248: fix all-zero metrics for fully-labelled binary fields

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,0 +1,46 @@
+# AGENTS.md — llm-validation-framework
+
+Agent entry point for this repo. Read before making changes. The working tree is the
+source of truth over stale docs.
+
+> **This is a public repository** (published to PyPI as `llmvalidate`). Everything here —
+> commits, branch names, PR titles, issues — is visible to the world. Do **not** reference internal tooling, customer names, or any non-public information in commit messages, code comments, or docs. However, you can mention internal tickets.
+
+## What this is
+
+`llmvalidate` — a standalone PyPI package that evaluates LLM-extracted structured data
+against ground truth. Source in `src/llmvalidate/`, tests in `tests/`.
+
+## Releases are automatic — your commit message controls the version
+
+This repo uses **python-semantic-release**. Every push to `master` (via merged PR) runs
+`.github/workflows/ci-release.yml`, which reads the **Conventional Commit** history since
+the last release, bumps the version (`src/llmvalidate/__init__.py` + `pyproject.toml`),
+tags it, and **publishes to PyPI**. There is no manual version bump — never edit
+`__version__` by hand.
+
+The prefix exists **only to trigger a release** — it is not a style rule for every commit.
+semantic-release scans all commits merged to `master` and bumps the version from the
+highest-ranked type it finds (`feat:` > `fix:`). So **one commit per PR carrying the right
+prefix is enough**; the rest can have any message you like. If no commit in the PR has a
+recognized type, **no release fires**. When a prefix is used, the type token must come first,
+before the colon.
+
+### Commit format (for the release-triggering commit)
+
+At least one commit in the PR should use:
+
+```
+<type>: <imperative description>
+```
+
+| Type            | Effect on version | Use for                          |
+|-----------------|-------------------|----------------------------------|
+| `fix:`          | patch (0.0.x)     | bug fixes                        |
+| `feat:`         | minor (0.x.0)     | new features                     |
+| `BREAKING CHANGE:` footer | major (x.0.0) | backward-incompatible changes |
+| `docs:`, `chore:`, `test:`, `refactor:` | no release | non-shipping changes |
+
+Examples:
+- `fix: correct all-zero metrics for binary fields`
+- `feat: add per-field confidence scoring`

--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -16,7 +16,15 @@ def compare_results_binary(expected, actual):
     if (is_expected_undefined(expected)):
         return {'TP': None, 'TN': None, 'FP': None, 'FN': None}
 
-    TP = 1 if expected is True and actual is True else 0 
+    # Fully-labelled binary columns get re-inferred to numpy bool dtype by convert_lists,
+    # so iterrows yields numpy.bool_ scalars; normalize those to native bool because the
+    # identity checks below (is True / is False) fail for numpy.bool_ (ONC-12248).
+    if isinstance(expected, np.bool_):
+        expected = bool(expected)
+    if isinstance(actual, np.bool_):
+        actual = bool(actual)
+
+    TP = 1 if expected is True and actual is True else 0
     FN = 1 if expected is True and actual is not True else 0 
     TN = 1 if expected is False and actual is False else 0
     FP = 1 if expected is False and actual is not False else 0

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -588,6 +588,53 @@ def test_metrics_with_confidence_levels():
             conf_rows = metrics_df[metrics_df.confidence == conf_level]
             assert len(conf_rows) > 0, f"Should have at least some rows for confidence level {conf_level}"
 
+def test_validate_fully_labelled_binary_field():
+    """
+    Regression test for ONC-12248: a FULLY labelled binary field (no NaN rows) passed
+    through validate with structure_callback=None must produce correct confusion counts.
+
+    When the binary column has no NaN, convert_lists (via DataFrame.map) re-infers it to a
+    numpy bool dtype, so iterrows() yields numpy.bool_ scalars. Comparing those by identity
+    (numpy.bool_(True) is True == False) used to silently zero out every confusion count.
+    """
+    src = pd.DataFrame({
+        "Has metastasis":      pd.Series([True, False, True, False], dtype=object),
+        "Res: Has metastasis": pd.Series([True, False, True, True],  dtype=object),
+    })
+
+    res_df, metrics_df = v.validate(
+        src,
+        ["Has metastasis"],
+        structure_callback=None,
+        output_folder=None,
+    )
+
+    # --- Per-row confusion checks (res_df) ---
+    # row0: expected True, actual True  -> TP
+    # row1: expected False, actual False -> TN
+    # row2: expected True, actual True  -> TP
+    # row3: expected False, actual True  -> FP
+    assert res_df.loc[0, 'TP: Has metastasis'] == 1
+    assert res_df.loc[1, 'TN: Has metastasis'] == 1
+    assert res_df.loc[2, 'TP: Has metastasis'] == 1
+    assert res_df.loc[3, 'FP: Has metastasis'] == 1
+
+    # This field has no confidence data, so get_metrics drops the 'confidence' column and
+    # there is a single (Overall) row per field; look it up directly by field.
+    def _agg(name):
+        return metrics_df.loc[metrics_df.field == 'Has metastasis', name].iloc[0]
+
+    # --- Aggregate confusion counts ---
+    assert _agg('TP') == 2
+    assert _agg('FP') == 1
+    assert _agg('FN') == 0
+    assert _agg('TN') == 1
+
+    # --- Aggregate metrics ---
+    assert _agg('precision (micro)') == pytest.approx(2/3)
+    assert _agg('recall (micro)') == pytest.approx(1.0)
+    assert _agg('F1 score (micro)') == pytest.approx(0.8)
+
 def test_reorder_result_columns():
     """Test that _reorder_result_columns groups columns with the same base name together."""
     

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -598,8 +598,8 @@ def test_validate_fully_labelled_binary_field():
     (numpy.bool_(True) is True == False) used to silently zero out every confusion count.
     """
     src = pd.DataFrame({
-        "Has metastasis":      pd.Series([True, False, True, False], dtype=object),
-        "Res: Has metastasis": pd.Series([True, False, True, True],  dtype=object),
+        "Has metastasis": pd.Series([True, False, True, False], dtype=bool),
+        "Res: Has metastasis": pd.Series([True, False, True, True], dtype=bool),
     })
 
     res_df, metrics_df = v.validate(


### PR DESCRIPTION
## Summary
- `compare_results_binary` compared boolean labels by **identity** (`expected is True` / `actual is True`). For a **fully-labelled** binary field, `convert_lists` (via `DataFrame.map`) re-infers the column to a numpy `bool` dtype, so `iterrows()` yields `numpy.bool_` scalars. `numpy.bool_(True) is True` is `False`, so every confusion count came out 0 — silently producing no precision/recall/F1.
- Fix: normalize `numpy.bool_` scalars to native Python `bool` before the existing identity checks. The truth table is preserved exactly for all other types (native bool, NaN, None, strings), so the partially-labelled path is unchanged.
- Added regression test `test_validate_fully_labelled_binary_field` covering the fully-labelled binary path (which `samples.csv` never exercised).

## Jira
ONC-12248

## Test plan
- [x] Full suite green: **73 passed, 0 failed**
- [x] New test fails without the fix (`TP: Has metastasis` was 0), passes with it
- [x] Verified expected metrics from the ticket spec: TP=2, FP=1, FN=0, TN=1 → precision=2/3, recall=1.0, F1=0.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)