### PR TITLE
ONC-12314: Reference medRxiv preprint in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,17 +13,6 @@ A comprehensive Python framework for evaluating LLM-extracted structured data ag
 The methodology behind this framework is described in a medRxiv preprint:
 [medRxiv 2026.05.18.26353541](https://www.medrxiv.org/content/10.64898/2026.05.18.26353541v1) — DOI: [10.64898/2026.05.18.26353541](https://doi.org/10.64898/2026.05.18.26353541)
 
-If you use `llmvalidate` in your work, please cite the preprint:
-
-```bibtex
-@misc{llmvalidate_preprint_2026,
-  howpublished = {medRxiv preprint},
-  year         = {2026},
-  doi          = {10.64898/2026.05.18.26353541},
-  url          = {https://www.medrxiv.org/content/10.64898/2026.05.18.26353541v1}
-}
-```
-
 ## ✨ Key Features
 
 - **Multi-field validation** - Binary (True/False), scalar (single values), and list (multiple values) data types

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,22 @@
 
 A comprehensive Python framework for evaluating LLM-extracted structured data against ground truth labels. Supports binary classification, scalar values, and list fields with detailed performance metrics, confidence-based evaluation, and statistical uncertainty quantification via non-parametric bootstrap confidence intervals.
 
+## 📄 Paper
+
+The methodology behind this framework is described in a medRxiv preprint:
+[medRxiv 2026.05.18.26353541](https://www.medrxiv.org/content/10.64898/2026.05.18.26353541v1) — DOI: [10.64898/2026.05.18.26353541](https://doi.org/10.64898/2026.05.18.26353541)
+
+If you use `llmvalidate` in your work, please cite the preprint:
+
+```bibtex
+@misc{llmvalidate_preprint_2026,
+  howpublished = {medRxiv preprint},
+  year         = {2026},
+  doi          = {10.64898/2026.05.18.26353541},
+  url          = {https://www.medrxiv.org/content/10.64898/2026.05.18.26353541v1}
+}
+```
+
 ## ✨ Key Features
 
 - **Multi-field validation** - Binary (True/False), scalar (single values), and list (multiple values) data types


### PR DESCRIPTION
Adds a "Paper" section near the top of `readme.md` linking the medRxiv preprint (https://www.medrxiv.org/content/10.64898/2026.05.18.26353541v1, DOI 10.64898/2026.05.18.26353541) and a minimal BibTeX block so `llmvalidate` users can cite the work. The citation deliberately carries only the DOI/URL/year — the preprint page, medRxiv API, and Crossref were unreachable from this environment, so no title/author metadata was added rather than risking fabricated details. Docs-only change; `docs:` commit prefix, so no release fires.

## Jira
ONC-12314

## Test plan
- [x] Full suite green (83 passed, 0 failed, in 8.84s)
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)