### PR TITLE
feat: hierarchical dictionaries (parent matching)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ The methodology behind this framework is described in a medRxiv preprint:
 - **Multi-field validation** - Binary (True/False), scalar (single values), and list (multiple values) data types
 - **Coded field support** - Score a value together with its code (ICD-10 / ICD-O-3, RxNorm) as two independent facets
 - **Partial labeling support** - Handle datasets where different cases have labels for different subsets of fields
+- **Parent matching** - Hierarchical dictionaries: a prediction that is the parent of the labeled value scores a partial match (0.5) instead of incorrect. 
+E.g. for ICD-10: `C00` "Malignant neoplasm of lip" is partially correct for label `C00.1` "Malignant neoplasm, external lower lip".
 - **Dual usage modes** - Validate pre-computed results OR run live LLM inference with validation  
 - **Comprehensive metrics** - Precision, recall, F1/F2, accuracy, specificity, with micro and macro aggregation where applicable
 - **Confidence analysis** - Automatic performance breakdown by confidence levels
@@ -180,6 +182,7 @@ A `validate()` run generates two timestamped CSV files (a third, CI metrics, is 
 **Non-Binary Fields:**  
 - `Cor/Mis/Spu: {Field}` - Item counts per row (Inc and TN are None for list fields)
 - `Cor/Inc/Mis/Spu: {Field} items` - Actual item lists
+- `Par: {Field}` / `Par: {Field} items` - Partial-match count and the labeled items whose parent was predicted (only when the field has a `hierarchy` entry; see [Hierarchical / partial match](#hierarchical--partial-match))
 - `Precision/Recall/F1/F2: {Field}` - Per-row metrics (list fields only)
 
 **System Columns:**
@@ -256,6 +259,44 @@ The following formulas apply to both binary classification and structured extrac
 | **F2 Score** | `5 × (P × R) / (4P + R)` | Recall-weighted F-score (emphasizes recall over precision) |
 
 Where P = Precision and R = Recall (calculated differently for each metric type).
+
+### Hierarchical / Partial Match
+
+Some concepts are hierarchical: a prediction can be *correct but less specific* than the label
+(e.g. label `TNBC` (Triple Negative Breast Cancer), prediction `BC` (Breast Cancer)). Pass a **per-field** hierarchy to `validate` to credit
+these as **partial** matches instead of outright wrong:
+
+```python
+results_df, metrics_df = validate(
+    source_df=df,
+    fields=["Diagnosis", "Stage"],
+    structure_callback=None,
+    hierarchy={
+        "Diagnosis": {"TNBC": "BC"},   # {child: parent} for this field
+        # fields absent here get no partial matching (default behavior)
+    },
+)
+```
+
+When a prediction equals the **parent** of the labeled child, the case scores as a **Partial**
+(`Par`) worth `0.5` in precision and recall rather than Incorrect:
+
+| Metric | Formula |
+|--------|---------|
+| **Precision** | `(cor + 0.5 × par) / (cor + inc + par + spu)` |
+| **Recall** | `(cor + 0.5 × par) / (cor + inc + par + mis)` |
+
+A single case that is purely a parent-hit therefore scores `0.5` precision, `0.5` recall → `0.5` F1.
+
+Two semantic properties:
+- **One level only** — only a *direct* parent counts; a grandparent scores as Incorrect.
+- **Direction matters** — credit is asymmetric: it is granted only when the prediction is the
+  parent of the label (less specific than the truth), **not** when the prediction is more
+  specific (a child) than the label.
+
+Output: for each field that has a hierarchy entry, results get a per-row `Par: {Field}` column
+and the metrics table gets a `par` column (aggregated partial count). Fields without a hierarchy
+entry produce identical output to a run with no hierarchy at all (no `Par:`/`Inc:` columns).
 
 ## Bootstrap Confidence Intervals
 

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,8 @@ The methodology behind this framework is described in a medRxiv preprint:
 - **Multi-field validation** - Binary (True/False), scalar (single values), and list (multiple values) data types
 - **Coded field support** - Score a value together with its code (ICD-10 / ICD-O-3, RxNorm) as two independent facets
 - **Partial labeling support** - Handle datasets where different cases have labels for different subsets of fields
-- **Parent matching** - Hierarchical dictionaries: a prediction that is the parent of the labeled value scores a partial match (0.5) instead of incorrect. 
-E.g. for ICD-10: `C00` "Malignant neoplasm of lip" is partially correct for label `C00.1` "Malignant neoplasm, external lower lip".
+- **Parent matching** - Hierarchical dictionaries: a prediction that is the parent of the labeled value scores a partial match (0.5) instead of incorrect.
+  E.g. for ICD-10: `C00` "Malignant neoplasm of lip" is partially correct for label `C00.1` "Malignant neoplasm, external lower lip".
 - **Dual usage modes** - Validate pre-computed results OR run live LLM inference with validation  
 - **Comprehensive metrics** - Precision, recall, F1/F2, accuracy, specificity, with micro and macro aggregation where applicable
 - **Confidence analysis** - Automatic performance breakdown by confidence levels

--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -63,22 +63,24 @@ def calculate_binary_metrics(TP, FP, FN, TN):
 
     return precision, recall, f1_score, f2_score, accuracy, specificity
 
-def compare_results_all(df, fields, parents={}, comparison_callback=None, raw_text_column_name: str = "raw_text"):
+def compare_results_all(df, fields, hierarchy={}, comparison_callback=None, raw_text_column_name: str = "raw_text"):
     """ For each case from df calls and for each field from 'fields' compares results with 'Res: '+field
         and adds columns 'Inc: '+field, 'Cor: '+field, 'Mis: '+field, 'Spu: '+field, 'Par: '+field
         Input
             'df' - pandas dataframe with input, labeled data and results in 'Res: ' columns
             'fields' - fields to compare results
-            'parents' - A dictionary where key is a child and value is a parent for partial match
-            - **comparison_callback (callable, optional)**: 
+            'hierarchy' - A PER-FIELD nested dictionary {field_name: {child: parent}} for partial
+                match. Each field is scored against its own {child: parent} map; fields absent from
+                'hierarchy' get no partial matching (default {} = no partial matching for any field).
+            - **comparison_callback (callable, optional)**:
                 A callback function that will be applied to each row to generate comparison results.
 
         Returns pandas data frame same as df but with added columns:
             'Cor: ' for Correct
-            'Inc: ' for Incorrect (scalar fields; for list fields only when 'parents' is provided)
+            'Inc: ' for Incorrect (scalar fields; for list fields only when the field has a hierarchy entry)
             'Mis: ' for Missing
             'Spu: ' for Spurious
-            'Par: ' for Partial (only when 'parents' is provided)
+            'Par: ' for Partial (only when the field has a hierarchy entry)
             'TN: ' for True Negative (scalar fields only; not defined for list fields)
     """
 
@@ -112,12 +114,14 @@ def compare_results_all(df, fields, parents={}, comparison_callback=None, raw_te
 
             actual = row['Res: ' + field]
 
-            if binary_fields[field]: 
+            field_hierarchy = hierarchy.get(field, {})
+
+            if binary_fields[field]:
                 # For binary fields, use the binary comparison function.
                 res = compare_results_binary(expected, actual)
                 res_items = {}
             else:
-                res_items = compare_results(expected, actual, parents)
+                res_items = compare_results(expected, actual, field_hierarchy)
 
                 # Convert lists to counts, preserving None values
                 res = {key: len(value) if value is not None else None for key, value in res_items.items()}
@@ -135,13 +139,13 @@ def compare_results_all(df, fields, parents={}, comparison_callback=None, raw_te
                     row['F1 score: ' + field] = f1_score
                     row['F2 score: ' + field] = f2_score
 
-                    if not parents:
-                        #we don't want useless columns if no parents anyway
+                    if not field_hierarchy:
+                        #we don't want useless columns if no hierarchy for this field anyway
                         del res['Incorrect'] #incorrect appear only if parent mismatch (only for lists)
                         del res_items['Incorrect']
 
-                if not parents:
-                    #we don't want useless columns if no parents anyway
+                if not field_hierarchy:
+                    #we don't want useless columns if no hierarchy for this field anyway
                     del res['Partial']      #partial appear only if parent match
                     del res_items['Partial']
 
@@ -408,7 +412,7 @@ def get_metrics(res_df, fields):
 
     return metrics
 
-def compare_results(expected, actual, parents={}):
+def compare_results(expected, actual, hierarchy={}):
     """
     Compares expected results with actual results, ignoring duplicates.
 
@@ -427,7 +431,7 @@ def compare_results(expected, actual, parents={}):
     Args:
     expected (int, float, str, list): The expected result.
     actual (int, float, str, list): The actual result.
-    parents : A dictionary where key is a child and value is a parent for partial match
+    hierarchy : A flat dictionary where key is a child and value is a parent for partial match
 
     Returns:
     dict: A dictionary with keys 'Correct', 'Incorrect', 'Missing', 'Spurious', and 'Partial', mapping to their respective lists.
@@ -469,7 +473,7 @@ def compare_results(expected, actual, parents={}):
     """
 
     # Convert dictionary keys to casefold for case-insensitive matching
-    parents = {k.casefold(): v.casefold() for k, v in parents.items()}
+    hierarchy = {k.casefold(): v.casefold() for k, v in hierarchy.items()}
 
     output = {'Correct': [], 'Incorrect': [], 'Missing': [], 'Spurious': [], 'Partial': []}
 
@@ -480,21 +484,21 @@ def compare_results(expected, actual, parents={}):
         # Convert all elements to lowercase strings for case-insensitive comparison
         # and remove duplicates by converting to sets.
         expected_set = normalize_list(expected)
-        expected_parents_set = {parents[s] for s in expected_set if s in parents}
-        
+        expected_parents_set = {hierarchy[s] for s in expected_set if s in hierarchy}
+
         actual_set = normalize_list(actual)
-        actual_parents_set = {parents[s] for s in actual_set if s in parents}
+        actual_parents_set = {hierarchy[s] for s in actual_set if s in hierarchy}
 
         output['Correct'] = list(expected_set & actual_set)  # matching exactly
 
         for missing in expected_set - actual_set - actual_parents_set:
-            if missing in parents and parents[missing] in actual_set:
+            if missing in hierarchy and hierarchy[missing] in actual_set:
                 output['Partial'].append(missing)  # actual set has parent value therefore Partial
             else:
                 output['Missing'].append(missing)
 
         for spurious in actual_set - expected_set - expected_parents_set:
-            if spurious in parents and parents[spurious] in expected_set:
+            if spurious in hierarchy and hierarchy[spurious] in expected_set:
                 output['Incorrect'].append(spurious)  # expected set has parent value therefore Incorrect
             else:
                 output['Spurious'].append(spurious)
@@ -516,7 +520,7 @@ def compare_results(expected, actual, parents={}):
             output['Spurious'] = [actual]
         elif not is_scalar_empty(expected) and is_scalar_empty(actual):
             output['Missing'] = [expected]
-        elif expected in parents and parents[expected] == actual:
+        elif expected in hierarchy and hierarchy[expected] == actual:
             output['Partial'] = [expected]  # actual value is a parent of expected
         else:
             output['Incorrect'] = [actual]
@@ -820,6 +824,7 @@ def validate(source_df, fields, structure_callback, output_folder=None, drop_col
              file_prefix = datetime.now().strftime("%Y-%m-%d %H-%M-%S"),
              raw_text_column_name = 'raw_text',
              comparison_callback = None,
+             hierarchy = {},
              max_workers: int | None = 1,
              use_threads: bool = True):
     """
@@ -845,10 +850,20 @@ def validate(source_df, fields, structure_callback, output_folder=None, drop_col
         A callback function that will be applied to each row to generate structured predictions.
         If None, assumes that source_df already contains "Res: " columns with results.
 
-    - **comparison_callback (callable, optional)**: 
+    - **comparison_callback (callable, optional)**:
         A callback function that will be applied to each row to generate comparison results.
 
-    - **output_folder (str, optional)**: 
+    - **hierarchy (dict, optional)**:
+        A PER-FIELD nested map ``{field: {child: parent}}`` enabling partial (hierarchical)
+        matching. Default ``{}`` means no partial matching (current behavior). For a given
+        field, when a prediction equals the *parent* of the labeled child (i.e. the prediction
+        is less specific than the truth), it scores as a **Partial** match worth 0.5 in both
+        precision and recall — ``(cor + 0.5*par)/denom`` — instead of Incorrect. Two semantic
+        properties: (1) only DIRECT parent matches (one level) count — a grandparent does not;
+        (2) credit is asymmetric — it is granted only when the prediction is the parent of the
+        label, not when the prediction is more specific (a child) than the label.
+
+    - **output_folder (str, optional)**:
         Directory where the output CSV files will be saved. 
         If not provided, results will only be returned as DataFrames.
 
@@ -917,7 +932,7 @@ def validate(source_df, fields, structure_callback, output_folder=None, drop_col
     
     ###################################
     # Analyse the results and calculate the metrics
-    res_df = compare_results_all(res_df, fields, parents={}, comparison_callback=comparison_callback, raw_text_column_name=raw_text_column_name)
+    res_df = compare_results_all(res_df, fields, hierarchy=hierarchy, comparison_callback=comparison_callback, raw_text_column_name=raw_text_column_name)
 
     # Save results
     if output_folder:

--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -115,6 +115,12 @@ def compare_results_all(df, fields, hierarchy={}, comparison_callback=None, raw_
             actual = row['Res: ' + field]
 
             field_hierarchy = hierarchy.get(field, {})
+            if field_hierarchy is None:
+                field_hierarchy = {}
+            elif not isinstance(field_hierarchy, dict):
+                raise TypeError(
+                    f"hierarchy[{field!r}] must be a dict of {{child: parent}}, got {type(field_hierarchy).__name__}"
+                )
 
             if binary_fields[field]:
                 # For binary fields, use the binary comparison function.

--- a/src/llmvalidate/validation.py
+++ b/src/llmvalidate/validation.py
@@ -86,6 +86,17 @@ def compare_results_all(df, fields, hierarchy={}, comparison_callback=None, raw_
 
     fields = [f for f in fields if f in df] #ignore fields which are not in columns (they may be added later by comparison_callback)
 
+    # hierarchy is a per-field map {field: {child: parent}}; fail fast with a clear
+    # message if a caller passes a flat {child: parent} (the pre-1.0 shape) or any
+    # non-dict value, rather than a cryptic .items() error deep in the row loop.
+    # None is tolerated per field (treated as "no hierarchy for this field").
+    bad_hierarchy = {f: v for f, v in hierarchy.items() if v is not None and not isinstance(v, dict)}
+    if bad_hierarchy:
+        raise TypeError(
+            "hierarchy must be a per-field map {field: {child: parent}}; "
+            f"these entries are not dicts: {sorted(bad_hierarchy)}"
+        )
+
     # Determine which fields are binary by looking at the unique non-empty expected values.
     binary_fields = {}
     for field in fields:
@@ -114,13 +125,8 @@ def compare_results_all(df, fields, hierarchy={}, comparison_callback=None, raw_
 
             actual = row['Res: ' + field]
 
-            field_hierarchy = hierarchy.get(field, {})
-            if field_hierarchy is None:
-                field_hierarchy = {}
-            elif not isinstance(field_hierarchy, dict):
-                raise TypeError(
-                    f"hierarchy[{field!r}] must be a dict of {{child: parent}}, got {type(field_hierarchy).__name__}"
-                )
+            # Shape already validated up front; None/missing -> no hierarchy for this field.
+            field_hierarchy = hierarchy.get(field) or {}
 
             if binary_fields[field]:
                 # For binary fields, use the binary comparison function.
@@ -478,8 +484,10 @@ def compare_results(expected, actual, hierarchy={}):
                     [a]          None  None  None  None  None
     """
 
-    # Convert dictionary keys to casefold for case-insensitive matching
-    hierarchy = {k.casefold(): v.casefold() for k, v in hierarchy.items()}
+    # Normalize keys/values the same way as expected/actual (float-parse then casefold),
+    # so the hierarchy matches however the compared values were normalized and tolerates
+    # non-string codes (e.g. numeric-coded enums) instead of raising on .casefold().
+    hierarchy = {normalize(k): normalize(v) for k, v in hierarchy.items()}
 
     output = {'Correct': [], 'Incorrect': [], 'Missing': [], 'Spurious': [], 'Partial': []}
 
@@ -830,9 +838,9 @@ def validate(source_df, fields, structure_callback, output_folder=None, drop_col
              file_prefix = datetime.now().strftime("%Y-%m-%d %H-%M-%S"),
              raw_text_column_name = 'raw_text',
              comparison_callback = None,
-             hierarchy = {},
              max_workers: int | None = 1,
-             use_threads: bool = True):
+             use_threads: bool = True,
+             hierarchy = {}):
     """
     Performs validation by applying a structuring callback to an input dataset and evaluating performance.
 

--- a/tests/compare_results_all_test.py
+++ b/tests/compare_results_all_test.py
@@ -173,3 +173,36 @@ def test_compare_results_all_mixed_fields():
     for col in expected_columns:
         assert col in res_df.columns, f"Missing column {col} in compare_results_all output"
 
+
+def test_compare_results_all_per_field_hierarchy():
+    """Hierarchy is PER-FIELD: only the field with a {child: parent} entry gets
+    Par:/Inc: columns; a field without an entry is scored exactly as before (no
+    Par:/Inc: columns)."""
+    df = pd.DataFrame({
+        # hierarchical list field: prediction 'bc' is the parent of the labeled child 'tnbc'
+        'Dx': [['tnbc']],
+        'Res: Dx': [['bc']],
+        # non-hierarchical list field: plain miss + spurious
+        'drugs': [['a']],
+        'Res: drugs': [['b']],
+    })
+
+    res_df = v.compare_results_all(df, ['Dx', 'drugs'], hierarchy={'Dx': {'tnbc': 'bc'}})
+
+    # ---- Hierarchical field: parent-of-label prediction scores Partial ----
+    assert 'Par: Dx' in res_df.columns
+    assert res_df.loc[0, 'Par: Dx'] == 1
+    # exact-match and outright-wrong counts are zero for this single partial hit
+    assert res_df.loc[0, 'Cor: Dx'] == 0
+    assert res_df.loc[0, 'Mis: Dx'] == 0
+    assert res_df.loc[0, 'Spu: Dx'] == 0
+    # Inc column is emitted for a hierarchical list field (here 0 for this case)
+    assert 'Inc: Dx' in res_df.columns
+    assert res_df.loc[0, 'Inc: Dx'] == 0
+
+    # ---- Non-hierarchical field: byte-identical behavior to no-hierarchy ----
+    assert 'Par: drugs' not in res_df.columns
+    assert 'Inc: drugs' not in res_df.columns
+    assert res_df.loc[0, 'Mis: drugs'] == 1
+    assert res_df.loc[0, 'Spu: drugs'] == 1
+

--- a/tests/compare_results_all_test.py
+++ b/tests/compare_results_all_test.py
@@ -206,3 +206,13 @@ def test_compare_results_all_per_field_hierarchy():
     assert res_df.loc[0, 'Mis: drugs'] == 1
     assert res_df.loc[0, 'Spu: drugs'] == 1
 
+
+def test_compare_results_all_rejects_non_per_field_hierarchy():
+    """A flat {child: parent} map (or any non-dict value) is rejected up front with a
+    clear TypeError, rather than failing deep in the row loop with a cryptic .items()
+    error. hierarchy must be the per-field shape {field: {child: parent}}."""
+    df = pd.DataFrame({'Dx': [['tnbc']], 'Res: Dx': [['bc']]})
+    with pytest.raises(TypeError, match="per-field"):
+        # flat shape mistakenly passed instead of {'Dx': {'tnbc': 'bc'}}
+        v.compare_results_all(df, ['Dx'], hierarchy={'tnbc': 'bc'})
+

--- a/tests/compare_results_test.py
+++ b/tests/compare_results_test.py
@@ -3,7 +3,7 @@ import llmvalidate.validation as v
 import pytest
 import math
 
-@pytest.mark.parametrize("expected, actual, parents, expected_output", [
+@pytest.mark.parametrize("expected, actual, hierarchy, expected_output", [
     # scalar values
     #   expected is not labeled so it does not make sense to compare results
     (None, "", {}, {'Correct': None, 'Incorrect': None, 'Missing': None, 'Spurious': None, 'Partial': None}),
@@ -79,8 +79,8 @@ import math
     ([4], math.nan, {}, {'Correct': [], 'Incorrect': [], 'Missing': [4.0], 'Spurious': [], 'Partial': []}),
     ([4], None, {}, {'Correct': [], 'Incorrect': [], 'Missing': [4.0], 'Spurious': [], 'Partial': []}),
 ])
-def test_compare_results(expected, actual, parents, expected_output):
-    result = v.compare_results(expected, actual, parents)
+def test_compare_results(expected, actual, hierarchy, expected_output):
+    result = v.compare_results(expected, actual, hierarchy)
     
     # For list comparisons, we need to sort the lists to compare them properly since order doesn't matter
     if result['Correct'] is not None:

--- a/tests/compare_results_test.py
+++ b/tests/compare_results_test.py
@@ -28,6 +28,8 @@ import math
     ("4", "4.0", {}, {'Correct': [4.0], 'Incorrect': [], 'Missing': [], 'Spurious': [], 'Partial': []}),
     ('apple', 'tree', { 'Apple': 'Tree' }, {'Correct': [], 'Incorrect': [], 'Missing': [], 'Spurious': [], 'Partial': ['apple']}),
     ('tree', 'apple', { 'Apple': 'Tree' }, {'Correct': [], 'Incorrect': ['apple'], 'Missing': [], 'Spurious': [], 'Partial': []}),
+    # numeric-coded hierarchy: keys/values are normalized like expected/actual (not raw casefold)
+    (4, 3, { 4: 3 }, {'Correct': [], 'Incorrect': [], 'Missing': [], 'Spurious': [], 'Partial': [4.0]}),
     #   expected is not empty but actual is empty
     ("female", nan, {}, {'Correct': [], 'Incorrect': [], 'Missing': ["female"], 'Spurious': [], 'Partial': []}),
     ("female", None, {}, {'Correct': [], 'Incorrect': [], 'Missing': ["female"], 'Spurious': [], 'Partial': []}),

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -713,6 +713,72 @@ def test_scalar_field_tn_reporting():
     assert pd.isna(drugs['specificity'])
 
 
+def test_validate_hierarchy_partial_match():
+    """End-to-end: passing a PER-FIELD hierarchy to validate() (structure_callback=None,
+    results supplied via 'Res: ' columns) makes a parent-of-label prediction score as a
+    Partial worth 0.5 in precision & recall.
+
+    Fields:
+      - 'grade'  : has a hierarchy {'g3': 'high'}; one labeled row where the prediction
+                   'high' is the DIRECT parent of the labeled child 'g3' -> pure partial hit.
+      - 'exact'  : no hierarchy; every row is an exact match -> micro F1 == 1.0.
+      - 'wrong'  : no hierarchy; every row is an unrelated wrong prediction -> Inc, micro 0.
+    """
+    src = pd.DataFrame({
+        'grade':      ['g3',  None, None],
+        'Res: grade': ['high', None, None],
+        'exact':      ['a', 'b', 'c'],
+        'Res: exact': ['a', 'b', 'c'],
+        'wrong':      ['x', 'y', 'm'],
+        'Res: wrong': ['z', 'w', 'n'],
+    })
+
+    res_df, metrics_df = v.validate(
+        src,
+        ['grade', 'exact', 'wrong'],
+        structure_callback=None,
+        output_folder=None,
+        hierarchy={'grade': {'g3': 'high'}},
+    )
+
+    # No confidence columns in this data -> get_metrics drops 'confidence', one row per field.
+    def _agg(field, name):
+        return metrics_df.loc[metrics_df.field == field, name].iloc[0]
+
+    # ---- Per-row: the parent-of-label prediction is a Partial ----
+    assert 'Par: grade' in res_df.columns
+    assert res_df.loc[0, 'Par: grade'] == 1
+    assert res_df.loc[0, 'Cor: grade'] == 0
+    assert res_df.loc[0, 'Inc: grade'] == 0
+
+    # ---- Metrics for the hierarchical field: par reflected, micro F1 == 0.5 ----
+    # Only row0 is labeled: cor=0, par=1, inc=0, spu=0, mis=0
+    # precision = (0 + 0.5*1) / (0 + 0 + 1 + 0) = 0.5
+    # recall    = (0 + 0.5*1) / (0 + 0 + 1 + 0) = 0.5
+    # F1        = 2*0.5*0.5 / (0.5 + 0.5)       = 0.5
+    assert _agg('grade', 'par') == 1
+    assert _agg('grade', 'cor') == 0
+    assert _agg('grade', 'precision (micro)') == pytest.approx(0.5)
+    assert _agg('grade', 'recall (micro)') == pytest.approx(0.5)
+    assert _agg('grade', 'F1 score (micro)') == pytest.approx(0.5)
+
+    # ---- Exact-match field (no hierarchy): scores 1.0, no Par column ----
+    assert 'Par: exact' not in res_df.columns
+    assert res_df.loc[0, 'Cor: exact'] == 1
+    assert _agg('exact', 'cor') == 3
+    assert _agg('exact', 'precision (micro)') == pytest.approx(1.0)
+    assert _agg('exact', 'F1 score (micro)') == pytest.approx(1.0)
+
+    # ---- Wrong field (no hierarchy): scores as Inc / 0, no Par column ----
+    assert 'Par: wrong' not in res_df.columns
+    assert res_df.loc[0, 'Inc: wrong'] == 1
+    assert res_df.loc[0, 'Cor: wrong'] == 0
+    assert _agg('wrong', 'inc') == 3
+    assert _agg('wrong', 'cor') == 0
+    assert _agg('wrong', 'precision (micro)') == pytest.approx(0.0)
+    assert _agg('wrong', 'F1 score (micro)') == 0
+
+
 def test_reorder_result_columns():
     """Test that _reorder_result_columns groups columns with the same base name together."""
     


### PR DESCRIPTION
## Summary

Adds support for **hierarchical data dictionaries** so a prediction that is the *parent* of the labeled value scores a **partial match (0.5)** instead of incorrect.

The low-level partial-match machinery already existed (a `Par` count weighted 0.5 in precision/recall) but was unreachable from the public `validate()` API and undocumented. This wires it up, makes it per-field, and documents it.

## Changes

- Rename the `parents` parameter to **`hierarchy`** in `compare_results` and `compare_results_all`.
- `compare_results_all` and `validate` now take a **per-field** map: `hierarchy={field: {child: parent}}`. The old flat/global-dict shape is removed.
- Expose **`validate(..., hierarchy=...)`** and thread it through (previously hardcoded to empty, so partial matching was never reachable).
- Emit `Par: {field}` and `Par: {field} items` per row, and aggregate `par` into micro precision/recall — `(cor + 0.5*par) / denom`.
- README: new Key Features bullet, a "Hierarchical / Partial Match" section, and the output-column docs.

## Semantics

- **One level only** — only a direct parent counts; a grandparent scores as Incorrect.
- **Asymmetric** — credit only when the prediction is the *parent* of the label (less specific), not the reverse.

## Example

For ICD-10, predicting `C00` ("Malignant neoplasm of lip") for a label of `C00.1` ("Malignant neoplasm, external lower lip") scores 0.5 instead of 0.

```python
validate(source_df=df, fields=["icd-10-code"], structure_callback=None,
         hierarchy={"icd-10-code": {"C00.1": "C00", "C00.2": "C00"}})
```

## Tests

Full suite green (86 passed). Adds a per-field `compare_results_all` test and an end-to-end `validate()` test (parent-hit → F1 0.5, exact → 1.0, wrong → 0). No existing test weakened.

## Release

Ships a minor version via semantic-release from the `feat:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)